### PR TITLE
Added maxItems support to cache updates

### DIFF
--- a/Upload/jscripts/MentionMe/mention_autocomplete.js
+++ b/Upload/jscripts/MentionMe/mention_autocomplete.js
@@ -787,6 +787,10 @@ var MentionMe = (function(m) {
 
 			// if we have content, clear out and get ready to build items
 			clear();
+			
+			if (items.length > maxItems) {
+				items.length = maxItems;
+			}
 
 			for (i = 0; i < items.length; i++) {
 				div.insert(new Element('div', {


### PR DESCRIPTION
maxItems's aim is to prevent X usernames (default to 5) to appear in the DOM when mentioning. It does work when initializing the popup but not when updating the popup. This pull request patches this behavior. 
