### PR TITLE
Provide Full Forum URL

### DIFF
--- a/Upload/inc/plugins/MentionMe/forum.php
+++ b/Upload/inc/plugins/MentionMe/forum.php
@@ -247,7 +247,7 @@ function mentionBuild($user)
 		// set up the user name link so that it displays correctly for the display group of the user
 		$username = format_name($username, $user['usergroup'], $user['displaygroup']);
 	}
-	$url = get_profile_link($user['uid']);
+	$url = $mybb->settings['bburl'] . "/" . get_profile_link($user['uid']);
 
 	// the HTML id property is used to store the uid of the mentioned user for MyAlerts (if installed)
 	return <<<EOF


### PR DESCRIPTION
I think that it is better to provide full forum url.

In our case this plugin didn't work because of this...