### PR TITLE
3.2.4 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## MentionMe 3.2.3
+## MentionMe 3.2.4
 
 A plugin for MyBB 1.8.x that allows Twitter-style tagging and integration with [MyAlerts](https://github.com/euantorano/MyAlerts)
 

--- a/Upload/inc/plugins/MentionMe/forum.php
+++ b/Upload/inc/plugins/MentionMe/forum.php
@@ -378,18 +378,23 @@ function mentionMeXMLHTTPgetNameCache()
 				FROM {$db->table_prefix}posts p
 				LEFT JOIN {$db->table_prefix}users u ON (p.uid=u.uid)
 				WHERE p.tid='{$tid}'
-				GROUP BY p.uid
-				ORDER BY MAX(p.pid) DESC
-				LIMIT {$limit}
+				ORDER BY p.pid DESC
 			");
 		} else {
-			$query = $db->simple_select('posts', 'username', "tid='{$tid}'", array("group_by" => "uid", "order_by" => 'MAX(pid)', "order_dir" => 'DESC', "limit" => $limit));
+			$query = $db->simple_select('posts', 'username', "tid='{$tid}'", array("order_by" => 'pid', "order_dir" => 'DESC'));
 		}
 
 		if ($db->num_rows($query) > 0) {
-			while ($user = $db->fetch_array($query)) {
+			$count = 0;
+			while ($count < $limit && $user = $db->fetch_array($query)) {
 				$key = mb_strtolower($user['username']);
+
+				if (isset($names['inThread'][$key])) {
+					continue;
+				}
+
 				$names['inThread'][$key] = $user;
+				$count++;
 			}
 		}
 	}

--- a/Upload/inc/plugins/mention.php
+++ b/Upload/inc/plugins/mention.php
@@ -14,7 +14,7 @@ if (!defined('IN_MYBB')) {
 
 // checked by other plugin files
 define('IN_MENTIONME', true);
-define('MENTIONME_VERSION', '3.2.3');
+define('MENTIONME_VERSION', '3.2.4');
 
 // register custom class autoloader
 spl_autoload_register('mentionMeClassAutoLoad');


### PR DESCRIPTION
**Fixes:**
- a bug where an incorrect setting name was used, disabling the ability to open mention links in a new window or tab (fixed by @SvePu)

**Changes:**
- The query to retrieve thread participants for the autocomplete popup proved to be quite intensive for larger forums. @chack1172 and I made some improvements to the SQL:PHP ratio and simplified the query for a nice increase in performance and efficiency.